### PR TITLE
Update ros2_control.xacro

### DIFF
--- a/mirte_description/mirte_master_description/urdf/ros2_control.xacro
+++ b/mirte_description/mirte_master_description/urdf/ros2_control.xacro
@@ -44,7 +44,7 @@
 <ros2_control name="ros2_arm_control" type="system">
       <hardware>
         <xacro:if value="$(arg sim)">
-          <plugin>ign_ros2_control/IgnitionSystem</plugin>
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:unless value="$(arg sim)">
           <plugin>mirte_master_arm_control/MirteMasterArmHWInterface</plugin>
@@ -86,7 +86,7 @@
 <ros2_control name="ros2_gripper_control" type="system">
      <hardware>
         <xacro:if value="$(arg sim)">
-          <plugin>ign_ros2_control/IgnitionSystem</plugin>
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:unless value="$(arg sim)">
           <plugin>mirte_master_arm_control/MirteMasterArmHWInterface</plugin>
@@ -140,7 +140,7 @@
       <odom_publish_frequency>100</odom_publish_frequency>
     </plugin>
     
-    <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+    <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
        <parameters>$(find mirte_base_control)/config/mirte_base_control.yaml</parameters>
        <xacro:if value="$(arg arm_enable)">
           <parameters>$(find mirte_master_arm_control)/config/mirte_master_arm_control.yaml</parameters>


### PR DESCRIPTION
ign_ros2_control -> gz_ros2_control

Doesn't change the functionality but we stop getting the warning:

```
[ign gazebo-1] Update the <ros2_control> tag and gazebo plugin to
[ign gazebo-1] <hardware>
[ign gazebo-1]   <plugin>gz_ros2_control/GazeboSimSystem</plugin>
[ign gazebo-1] </hardware>
[ign gazebo-1] <gazebo>
[ign gazebo-1]   <plugin filename="gz_ros2_control-system"name="gz_ros2_control::GazeboSimROS2ControlPlugin">
[ign gazebo-1]     ...
[ign gazebo-1]   </plugin>
[ign gazebo-1] </gazebo>
```