### PR TITLE
Add noise to odom, lidar and imu

### DIFF
--- a/mirte_description/mirte_master_description/urdf/lidar.xacro
+++ b/mirte_description/mirte_master_description/urdf/lidar.xacro
@@ -99,11 +99,13 @@
                     <max>12</max>
                     <resolution>0.015</resolution>
                 </range>
-                <noise>
-                  <type>gaussian</type>
-                  <mean>0</mean>
-                  <stddev>0.0165</stddev>
-                </noise>
+                <xacro:if value="$(arg noise)">
+                  <noise>
+                    <type>gaussian</type>
+                    <mean>0</mean>
+                    <stddev>0.0165</stddev>
+                  </noise>
+                </xacro:if>
             </lidar>
         </sensor>
     </gazebo>

--- a/mirte_description/mirte_master_description/urdf/lidar.xacro
+++ b/mirte_description/mirte_master_description/urdf/lidar.xacro
@@ -97,8 +97,13 @@
                 <range>
                     <min>0.03</min>
                     <max>12</max>
-                    <resolution>0.01</resolution>
+                    <resolution>0.015</resolution>
                 </range>
+                <noise>
+                  <type>gaussian</type>
+                  <mean>0</mean>
+                  <stddev>0.0165</stddev>
+                </noise>
             </lidar>
         </sensor>
     </gazebo>

--- a/mirte_description/mirte_master_description/urdf/mirte_master.xacro
+++ b/mirte_description/mirte_master_description/urdf/mirte_master.xacro
@@ -13,6 +13,7 @@
   <xacro:arg name="depth_camera_enable" default="True" />
   <xacro:arg name="imu_enable" default="True" />
   <xacro:arg name="sim" default="False" />
+  <xacro:arg name="noise" default="True" />
 
   <xacro:property name="camera_name" value="camera" lazy_eval="False"/>
   <xacro:property name="namespace" value="" scope="global" lazy_eval="False"/>

--- a/mirte_description/mirte_master_description/urdf/mirte_master_base.gazebo.xacro
+++ b/mirte_description/mirte_master_description/urdf/mirte_master_base.gazebo.xacro
@@ -11,6 +11,60 @@
       <topic>imu</topic>
       <pose>0 0 0 0 0 0</pose>
       <gz_frame_id>imu_link</gz_frame_id>
+      <imu>
+        <angular_velocity>
+          <x>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+              <bias_mean>0.0000075</bias_mean>
+              <bias_stddev>0.0000008</bias_stddev>
+            </noise>
+          </x>
+          <y>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+              <bias_mean>0.0000075</bias_mean>
+              <bias_stddev>0.0000008</bias_stddev>
+            </noise>
+          </y>
+          <z>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+              <bias_mean>0.0000075</bias_mean>
+              <bias_stddev>0.0000008</bias_stddev>
+            </noise>
+          </z>
+        </angular_velocity>
+        <linear_acceleration>
+          <x>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+              <bias_mean>0.1</bias_mean>
+              <bias_stddev>0.001</bias_stddev>
+            </noise>
+          </x>
+          <y>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+              <bias_mean>0.1</bias_mean>
+              <bias_stddev>0.001</bias_stddev>
+            </noise>
+          </y>
+          <z>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+              <bias_mean>0.1</bias_mean>
+              <bias_stddev>0.001</bias_stddev>
+            </noise>
+          </z>
+        </linear_acceleration>
+      </imu>
     </sensor>
    </gazebo>
   </xacro:if>

--- a/mirte_description/mirte_master_description/urdf/mirte_master_base.gazebo.xacro
+++ b/mirte_description/mirte_master_description/urdf/mirte_master_base.gazebo.xacro
@@ -11,60 +11,62 @@
       <topic>imu</topic>
       <pose>0 0 0 0 0 0</pose>
       <gz_frame_id>imu_link</gz_frame_id>
-      <imu>
-        <angular_velocity>
-          <x>
-            <noise type="gaussian">
-              <mean>0.0</mean>
-              <stddev>2e-4</stddev>
-              <bias_mean>0.0000075</bias_mean>
-              <bias_stddev>0.0000008</bias_stddev>
-            </noise>
-          </x>
-          <y>
-            <noise type="gaussian">
-              <mean>0.0</mean>
-              <stddev>2e-4</stddev>
-              <bias_mean>0.0000075</bias_mean>
-              <bias_stddev>0.0000008</bias_stddev>
-            </noise>
-          </y>
-          <z>
-            <noise type="gaussian">
-              <mean>0.0</mean>
-              <stddev>2e-4</stddev>
-              <bias_mean>0.0000075</bias_mean>
-              <bias_stddev>0.0000008</bias_stddev>
-            </noise>
-          </z>
-        </angular_velocity>
-        <linear_acceleration>
-          <x>
-            <noise type="gaussian">
-              <mean>0.0</mean>
-              <stddev>1.7e-2</stddev>
-              <bias_mean>0.1</bias_mean>
-              <bias_stddev>0.001</bias_stddev>
-            </noise>
-          </x>
-          <y>
-            <noise type="gaussian">
-              <mean>0.0</mean>
-              <stddev>1.7e-2</stddev>
-              <bias_mean>0.1</bias_mean>
-              <bias_stddev>0.001</bias_stddev>
-            </noise>
-          </y>
-          <z>
-            <noise type="gaussian">
-              <mean>0.0</mean>
-              <stddev>1.7e-2</stddev>
-              <bias_mean>0.1</bias_mean>
-              <bias_stddev>0.001</bias_stddev>
-            </noise>
-          </z>
-        </linear_acceleration>
-      </imu>
+      <xacro:if value="$(arg noise)">
+        <imu>
+          <angular_velocity>
+            <x>
+              <noise type="gaussian">
+                <mean>0.0</mean>
+                <stddev>2e-4</stddev>
+                <bias_mean>0.0000075</bias_mean>
+                <bias_stddev>0.0000008</bias_stddev>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0.0</mean>
+                <stddev>2e-4</stddev>
+                <bias_mean>0.0000075</bias_mean>
+                <bias_stddev>0.0000008</bias_stddev>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0.0</mean>
+                <stddev>2e-4</stddev>
+                <bias_mean>0.0000075</bias_mean>
+                <bias_stddev>0.0000008</bias_stddev>
+              </noise>
+            </z>
+          </angular_velocity>
+          <linear_acceleration>
+            <x>
+              <noise type="gaussian">
+                <mean>0.0</mean>
+                <stddev>1.7e-2</stddev>
+                <bias_mean>0.1</bias_mean>
+                <bias_stddev>0.001</bias_stddev>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0.0</mean>
+                <stddev>1.7e-2</stddev>
+                <bias_mean>0.1</bias_mean>
+                <bias_stddev>0.001</bias_stddev>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0.0</mean>
+                <stddev>1.7e-2</stddev>
+                <bias_mean>0.1</bias_mean>
+                <bias_stddev>0.001</bias_stddev>
+              </noise>
+            </z>
+          </linear_acceleration>
+        </imu>
+      </xacro:if>
     </sensor>
    </gazebo>
   </xacro:if>

--- a/mirte_description/mirte_master_description/urdf/ros2_control.xacro
+++ b/mirte_description/mirte_master_description/urdf/ros2_control.xacro
@@ -132,12 +132,12 @@
 <gazebo>
     <plugin filename="ignition-gazebo-odometry-publisher-system"
             name="ignition::gazebo::systems::OdometryPublisher">
-      <!-- Default from gz-sim was set to /model/mpo_700/topic and /mpo_700/frame on July 2023 -->
       <odom_frame>odom</odom_frame> 
       <odom_covariance_topic>odom</odom_covariance_topic>
       <tf_topic>tf</tf_topic>
       <robot_base_frame>base_link</robot_base_frame>
       <odom_publish_frequency>100</odom_publish_frequency>
+      <gaussian_noise>0.05</gaussian_noise>
     </plugin>
     
     <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">

--- a/mirte_description/mirte_master_description/urdf/ros2_control.xacro
+++ b/mirte_description/mirte_master_description/urdf/ros2_control.xacro
@@ -137,7 +137,9 @@
       <tf_topic>tf</tf_topic>
       <robot_base_frame>base_link</robot_base_frame>
       <odom_publish_frequency>100</odom_publish_frequency>
-      <gaussian_noise>0.05</gaussian_noise>
+      <xacro:if value="$(arg noise)">
+        <gaussian_noise>0.05</gaussian_noise>
+      </xacro:if>
     </plugin>
     
     <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">


### PR DESCRIPTION
Add noise to odom, lidar and imu to make the simulation more realistic. The noise is very small. The lidar resolution and noise are approximately equivalent to what is described in the datasheet. 

<img width="1430" height="300" alt="image" src="https://github.com/user-attachments/assets/a1a6eac5-fac4-4260-a4da-05b7c6a046f5" />

Lidar datasheet: https://bucket-download.slamtec.com/2d4664be9f9f5c748f3b608f2cf1862962b168eb/SLAMTEC_rplidar_datasheet_C1_v1.1_en.pdf