### PR TITLE
fix simulation odom_topic and decrease pub freq

### DIFF
--- a/mirte_description/mirte_master_description/urdf/ros2_control.xacro
+++ b/mirte_description/mirte_master_description/urdf/ros2_control.xacro
@@ -134,10 +134,10 @@
             name="ignition::gazebo::systems::OdometryPublisher">
       <!-- Default from gz-sim was set to /model/mpo_700/topic and /mpo_700/frame on July 2023 -->
       <odom_frame>odom</odom_frame> 
-      <odom_covariance_topic>odom</odom_covariance_topic>
+      <odom_topic>odom</odom_topic>
       <tf_topic>tf</tf_topic>
       <robot_base_frame>base_link</robot_base_frame>
-      <odom_publish_frequency>100</odom_publish_frequency>
+      <odom_publish_frequency>50</odom_publish_frequency>
     </plugin>
     
     <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">


### PR DESCRIPTION
Change the Odometry plugin to publish odom without covariance in the `/odom` topic instead of with covariance into the `/odom` topic. Usually, it is expected that the message type in the odom topic to be without covariance.
We could publish both if needed, but I don't think it is needed.

I also decreased the frequency, 100 is a bit too much and it doesn't add anything