### PR TITLE
Add arm_home_publisher to publish arm home position.

### DIFF
--- a/mirte_control/mirte_master_arm_control/CMakeLists.txt
+++ b/mirte_control/mirte_master_arm_control/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(trajectory_msgs REQUIRED)
 # find dependencies
 set(THIS_PACKAGE_INCLUDE_DEPENDS
     hardware_interface
@@ -23,6 +24,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     std_srvs
     std_msgs
     control_toolbox
+    trajectory_msgs
     yaml_cpp_vendor)
 
 # find dependencies
@@ -51,13 +53,26 @@ target_compile_definitions(${PROJECT_NAME}
 # Export hardware plugins
 pluginlib_export_plugin_description_file(hardware_interface ${PROJECT_NAME}.xml)
 
+add_executable(arm_home_publisher src/mirte_master_arm_control/arm_home_publisher.cpp)
+ament_target_dependencies(arm_home_publisher ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_include_directories(arm_home_publisher PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+install(TARGETS arm_home_publisher
+  DESTINATION lib/${PROJECT_NAME})
+
 # INSTALL
 install(DIRECTORY hardware/include/ DESTINATION include/${PROJECT_NAME})
 # install( DIRECTORY description/launch description/ros2_control
 # description/urdf description/rviz DESTINATION share/${PROJECT_NAME} )
-install(DIRECTORY bringup/launch bringup/config 
-bringup/urdf
-        DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY
+  bringup/launch
+  bringup/config
+  bringup/urdf
+  DESTINATION share/${PROJECT_NAME})
+
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}/)
 install(
   TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}

--- a/mirte_control/mirte_master_arm_control/config/arm_nav_home_position.yml
+++ b/mirte_control/mirte_master_arm_control/config/arm_nav_home_position.yml
@@ -1,0 +1,5 @@
+arm_home_publisher:
+  ros__parameters:
+    joint_names: ['shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_joint']
+    positions: [-0.0014559920463634742, 1.415918625432497, -1.5706991018294059, -1.570750919481129]
+    time_from_start: 5.0

--- a/mirte_control/mirte_master_arm_control/include/mirte_master_arm_control/arm_home_publisher.hpp
+++ b/mirte_control/mirte_master_arm_control/include/mirte_master_arm_control/arm_home_publisher.hpp
@@ -1,0 +1,37 @@
+//  Copyright 2025 Robust Robotic Systems, Cognitive Robotics, TU Delft
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+#include "control_msgs/action/follow_joint_trajectory.hpp"
+#include "trajectory_msgs/msg/joint_trajectory.hpp"
+
+class ArmHomePublisher : public rclcpp::Node
+{
+public:
+    ArmHomePublisher();
+
+private:
+    void timer_callback();
+
+    trajectory_msgs::msg::JointTrajectory traj_msg_;
+    rclcpp::TimerBase::SharedPtr timer_;
+	rclcpp::CallbackGroup::SharedPtr callback_group_action_client_;
+  	rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::SharedPtr action_cli_;
+	bool arm_goal_sent_ = false;
+};

--- a/mirte_control/mirte_master_arm_control/src/mirte_master_arm_control/arm_home_publisher.cpp
+++ b/mirte_control/mirte_master_arm_control/src/mirte_master_arm_control/arm_home_publisher.cpp
@@ -1,0 +1,94 @@
+//  Copyright 2025 Robust Robotic Systems, Cognitive Robotics, TU Delft
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#include <chrono>
+#include "mirte_master_arm_control/arm_home_publisher.hpp"
+
+using namespace std::chrono_literals;
+
+using FollowGoalHandle =    
+    rclcpp_action::ClientGoalHandle<control_msgs::action::FollowJointTrajectory>;
+
+ArmHomePublisher::ArmHomePublisher()
+    : Node("arm_home_publisher")
+{
+    // Declare params with defaults if needed
+    this->declare_parameter("joint_names", rclcpp::PARAMETER_STRING_ARRAY);
+    this->declare_parameter("positions", rclcpp::PARAMETER_DOUBLE_ARRAY);
+    this->declare_parameter("time_from_start", 5.0);
+
+    auto joint_names = this->get_parameter("joint_names").as_string_array();
+    auto positions = this->get_parameter("positions").as_double_array();
+    double time_from_start = this->get_parameter("time_from_start").as_double();
+
+    if (joint_names.size() != positions.size() || joint_names.empty()) {
+		RCLCPP_ERROR(this->get_logger(), "joint_names and positions must have same nonzero length.");
+		rclcpp::shutdown();
+		return;
+    }
+
+    traj_msg_.joint_names.assign(joint_names.begin(), joint_names.end());
+
+    trajectory_msgs::msg::JointTrajectoryPoint pt;
+    pt.positions.assign(positions.begin(), positions.end());
+    pt.time_from_start = rclcpp::Duration::from_seconds(time_from_start);
+    traj_msg_.points.push_back(pt);
+
+    action_cli_ = rclcpp_action::create_client<control_msgs::action::FollowJointTrajectory>(
+      this,
+      "mirte_master_arm_controller/follow_joint_trajectory",
+      callback_group_action_client_
+    );
+
+    timer_ = this->create_wall_timer(
+        500ms, std::bind(&ArmHomePublisher::timer_callback, this));
+}
+
+void ArmHomePublisher::timer_callback()
+{
+    if(action_cli_->action_server_is_ready() && !arm_goal_sent_){
+        control_msgs::action::FollowJointTrajectory::Goal arm_position_goal;
+        arm_position_goal.trajectory = traj_msg_;
+
+        auto send_goal_options =
+            rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::SendGoalOptions();
+        
+        send_goal_options.result_callback = [this](auto) {
+            RCLCPP_INFO(this->get_logger(), "Arm in initial arm pose!");
+            timer_->cancel();
+            arm_goal_sent_ = false;
+            rclcpp::shutdown();
+        };
+
+        send_goal_options.goal_response_callback = [this](FollowGoalHandle::SharedPtr goal_handle) {
+            if (!goal_handle) {
+                RCLCPP_ERROR(this->get_logger(), "Goal was rejected by server. Retrying.");
+                arm_goal_sent_ = false;
+            } else {
+                RCLCPP_INFO(this->get_logger(), "Goal accepted by server, waiting for result");
+            }
+        };
+
+        action_cli_->async_send_goal(arm_position_goal, send_goal_options);
+        RCLCPP_INFO(this->get_logger(), "Published initial arm pose!");
+        arm_goal_sent_ = true;
+    }
+}
+
+int main(int argc, char ** argv)
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<ArmHomePublisher>();
+    rclcpp::spin(node);
+    return 0;
+}

--- a/mirte_description/mirte_master_description/urdf/ros2_control.xacro
+++ b/mirte_description/mirte_master_description/urdf/ros2_control.xacro
@@ -42,20 +42,20 @@
 
 
 <ros2_control name="ros2_arm_control" type="system">
-      <hardware>
-        <xacro:if value="$(arg sim)">
-          <plugin>ign_ros2_control/IgnitionSystem</plugin>
-        </xacro:if>
-        <xacro:unless value="$(arg sim)">
-          <plugin>mirte_master_arm_control/MirteMasterArmHWInterface</plugin>
-        </xacro:unless>
-      </hardware>
+    <hardware>
+      <xacro:if value="$(arg sim)">
+        <plugin>ign_ros2_control/IgnitionSystem</plugin>
+      </xacro:if>
+      <xacro:unless value="$(arg sim)">
+        <plugin>mirte_master_arm_control/MirteMasterArmHWInterface</plugin>
+      </xacro:unless>
+    </hardware>
 
-   <joint name="shoulder_pan_joint">
+    <joint name="shoulder_pan_joint">
         <command_interface name="position"/>
         <state_interface name="position"/>
         <state_interface name="velocity" />
-   </joint>
+    </joint>
 
     <joint name="shoulder_lift_joint">
         <command_interface name="position"/>


### PR DESCRIPTION
Add arm_home_publisher to set arm home position. When the arm home position is set, the arm goes to the following position:

<img width="688" height="630" alt="image" src="https://github.com/user-attachments/assets/5cf53d34-2050-420a-8619-7e30156439eb" />

In this position, the arm is not detected by the lidar anymore. Closes: https://github.com/kas-lab/mirte_navigation/issues/12
